### PR TITLE
Adding support to control vpet by keyboard

### DIFF
--- a/client/src/components/PET.vue
+++ b/client/src/components/PET.vue
@@ -195,6 +195,7 @@ export default {
     mounted() {
         if(!this.readOnly) {
             this.initializeShake();
+            window.addEventListener("keyup", this.handleKey);
         }
     },
     methods: {
@@ -346,6 +347,40 @@ export default {
         },
         sendParentMessage() {
             this.$emit('dragstart');
+        },
+        handleKey(e) {
+            const convertions = {
+                38: {
+                    name: "upEvent",
+                    value: Events.Up
+                },
+                40: {
+                    name: "downEvent",
+                    value: Events.Down
+                },
+                37: {
+                    name: "leftEvent",
+                    value: Events.Left
+                },
+                39: {
+                    name: "rightEvent",
+                    value: Events.Right
+                },
+                13: {
+                    name: "confirmationEvent",
+                    value: Events.Confirmation
+                },
+                27: {
+                    name: "cancelEvent",
+                    value: Events.Cancel
+                },
+            };
+            const selectedConvertion = convertions[e.keyCode];
+            if (selectedConvertion === undefined || this.readOnly || !this.isCoverOpened) {
+                return;
+            }
+
+            EventBus.$emit(selectedConvertion.value, selectedConvertion.name);
         }
     }
 }


### PR DESCRIPTION
Found out about your app thanks to a YouTube video and tried it out, i thought it was pretty cool but really hard to play in my PC since everything uses heavily the mouse, this PR is to add support keyboard controls for navigation and such.
Directional keys serve as the directional buttons, Enter is confirm and Esc is cancel, it's a really simple implementation just to see what you think about it